### PR TITLE
Bugfig/#34

### DIFF
--- a/src/common/global.css
+++ b/src/common/global.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans+KR&display=swap');
+
 * {
   box-sizing: border-box;
+  font-family: 'Noto Sans KR', sans-serif;
 }

--- a/src/components/ContactCard/index.tsx
+++ b/src/components/ContactCard/index.tsx
@@ -23,13 +23,11 @@ const ContactCardLinks = () => (
 );
 
 const ContactCardCopyright = styled.span.attrs({ children: '© 2019 Snack Project' })`
-  font-family: SFProDisplay;
   font-size: 12px;
   color: #93939f;
 `;
 
 const ContactCardLink = styled.div`
-  font-family: SFProDisplay;
   font-size: 16px;
   font-weight: 500;
   text-align: center;

--- a/src/components/ExternalLink/index.tsx
+++ b/src/components/ExternalLink/index.tsx
@@ -29,7 +29,6 @@ const LinkImg = styled.img`
 `;
 
 const LinkHrefWrapper = styled.div`
-  font-family: SFProDisplay;
   font-size: 12px;
   color: #756e6e;
 `;
@@ -41,7 +40,6 @@ const ExternalLinkWrapper = styled.div`
 `;
 
 const LinkTitleWrapper = styled.div`
-  font-family: SFProDisplay;
   font-size: 14px;
   font-weight: 500;
   color: #121111;

--- a/src/components/News/Tags.tsx
+++ b/src/components/News/Tags.tsx
@@ -16,7 +16,6 @@ const Tags: FunctionComponent<ITagsProps> = ({ tags }) => (
 );
 
 const Tag = styled.div<ITag>`
-  font-family: SFProDisplay;
   font-size: 11px;
   font-weight: 500;
   color: #fefefe;

--- a/src/components/News/index.tsx
+++ b/src/components/News/index.tsx
@@ -129,7 +129,6 @@ const CreatedWeekLabel: FunctionComponent<{ date: number }> = ({ date }) => {
 };
 
 const Title = styled.div`
-  font-family: SFProDisplay;
   font-size: 19px;
   font-weight: 600;
   color: #121111;
@@ -141,7 +140,6 @@ const Title = styled.div`
 `;
 
 const Content = styled.div<{ expanded?: boolean }>`
-  font-family: AppleSDGothicNeo;
   font-size: 14px;
   line-height: 1.43;
   color: #121111;
@@ -160,7 +158,6 @@ const Content = styled.div<{ expanded?: boolean }>`
 `;
 
 const MoreButton = styled.div.attrs({ children: '더보기' })`
-  font-family: SFProDisplay;
   font-size: 14px;
   line-height: 2.4;
   color: #b6b6c0;
@@ -176,7 +173,6 @@ const IconLabelImg = styled.img`
 `;
 
 const IconLabelText = styled.span`
-  font-family: SFProText;
   font-size: 13px;
   color: #595966;
 `;

--- a/src/components/PlatformListCard/index.tsx
+++ b/src/components/PlatformListCard/index.tsx
@@ -22,7 +22,6 @@ export const PlatformListCard = () => (
 const PlatformListCardTitle = styled.div.attrs({
   children: '스낵뉴스를 원하는 플랫폼에서 챙겨보세요',
 })`
-  font-family: SFProDisplay;
   font-size: 17px;
   font-weight: 600;
   color: #000000;
@@ -63,7 +62,6 @@ const PlatformCardWrapper = styled.a`
 `;
 
 const PlatformCardLabel = styled.div`
-  font-family: SFProDisplay;
   font-size: 12px;
   font-weight: 500;
   text-align: center;

--- a/src/pages/Menu/index.tsx
+++ b/src/pages/Menu/index.tsx
@@ -67,7 +67,6 @@ const CloseButton = styled.img.attrs({ src: cancelWhite })`
 `;
 
 const MenuTitle = styled.div.attrs({ children: 'Menu' })`
-  font-family: Gelion;
   font-size: 24px;
   font-weight: 600;
   color: #fefefe;
@@ -87,7 +86,6 @@ const MenuLinkList = () => {
 };
 
 const MenuLink = styled.div`
-  font-family: SFProDisplay;
   font-size: 24px;
   font-weight: bold;
   line-height: normal;

--- a/src/templates/CompanyList/CompanyItem.tsx
+++ b/src/templates/CompanyList/CompanyItem.tsx
@@ -87,7 +87,6 @@ const CompanyIconImg = styled.img`
 
 /* CompanyLabel 컴포넌트 */
 const CompanyLabel = styled.span`
-  font-family: SFProDisplay;
   font-size: 14px;
   font-weight: 500;
   color: #121111;

--- a/src/templates/CompanyListCard/index.tsx
+++ b/src/templates/CompanyListCard/index.tsx
@@ -57,7 +57,9 @@ const CompanyBox: FunctionComponent<ICompany> = ({ logoImg, companyName }) => (
       {
         el: (
           <Center>
-            <CompanyBoxLogo src={logoImg} />
+            <CompanyBoxDiv>
+              <CompanyBoxLogo src={logoImg} />
+            </CompanyBoxDiv>
           </Center>
         ),
         bottom: '12px',
@@ -80,9 +82,16 @@ const CompanyBoxWrapper = styled(ColListLayout.Detail)`
   border: solid 0.5px #d6d6db;
 `;
 
+const CompanyBoxDiv = styled.div`
+  display: flex;
+  max-width: 72px;
+  max-height: 35px;
+  min-height: 35px;
+  align-items: center;
+  justify-content: center;
+`;
 const CompanyBoxLogo = styled.img`
-  width: 70.6px;
-  height: 27.2px;
+  width: 100%;
 `;
 
 const CompanyBoxLabel = styled.div`

--- a/src/templates/CompanyListCard/index.tsx
+++ b/src/templates/CompanyListCard/index.tsx
@@ -37,14 +37,12 @@ export const CompanyListCard: FunctionComponent<ICompanyListCardProps> = props =
 };
 
 const CompanyListCardTitle = styled.div`
-  font-family: SFProDisplay;
   font-size: 17px;
   font-weight: 600;
   color: #000000;
 `;
 
 const CompanyListCardMoreLink = styled.div.attrs({ children: '모두보기' })`
-  font-family: AppleSDGothicNeo;
   font-size: 13px;
   color: #0b66f7;
 `;
@@ -95,7 +93,6 @@ const CompanyBoxLogo = styled.img`
 `;
 
 const CompanyBoxLabel = styled.div`
-  font-family: AppleSDGothicNeo;
   font-size: 12px;
   color: #595966;
 `;

--- a/src/templates/Footer/components/FooterLinkList.tsx
+++ b/src/templates/Footer/components/FooterLinkList.tsx
@@ -15,7 +15,6 @@ export const FooterLinkList = () => (
 
 /* FooterLink 컴포넌트 */
 const FooterLink = styled.a`
-  font-family: SFProDisplay;
   font-size: 13px;
   font-weight: 500;
   text-align: center;

--- a/src/templates/Footer/components/FooterLinkList.tsx
+++ b/src/templates/Footer/components/FooterLinkList.tsx
@@ -15,7 +15,6 @@ export const FooterLinkList = () => (
 
 /* FooterLink 컴포넌트 */
 const FooterLink = styled.a`
-  width: 65px;
   font-family: SFProDisplay;
   font-size: 13px;
   font-weight: 500;

--- a/src/templates/RecommendNewsList/index.tsx
+++ b/src/templates/RecommendNewsList/index.tsx
@@ -29,7 +29,6 @@ export const RecommendNewsList = () => {
 const RecommendNewsListTitle = styled.div.attrs({
   children: '커머스, 이런 기사도 읽어보세요.',
 })`
-  font-family: SFProDisplay;
   font-size: 17px;
   font-weight: 500;
   color: #121111;
@@ -41,7 +40,6 @@ const RecommendNewsThumbnail = styled.img`
 `;
 
 const RecommendNewsTitle = styled.div`
-  font-family: SFProDisplay;
   font-size: 16px;
   line-height: 1.25;
   color: #121111;

--- a/src/templates/SelectBox/Label.tsx
+++ b/src/templates/SelectBox/Label.tsx
@@ -22,7 +22,6 @@ const Label = styled.div.attrs<{ text: string }>(({ text }) => ({
     </LabelWrapper>
   ),
 }))<{ text: string }>`
-  font-family: SFProDisplay;
   font-size: 17px;
   font-weight: 600;
   color: #121111;

--- a/src/templates/SelectItemListBox/SelectItem.tsx
+++ b/src/templates/SelectItemListBox/SelectItem.tsx
@@ -20,7 +20,6 @@ const SelectItem: FunctionComponent<ISelectItemProps> = ({ label, selected }) =>
 };
 
 const SelectItemLabel = styled.div`
-  font-family: SFProText;
   font-size: 15px;
   font-weight: 500;
   color: #121111;

--- a/src/templates/SelectItemListBox/index.tsx
+++ b/src/templates/SelectItemListBox/index.tsx
@@ -53,7 +53,6 @@ const SelectItemListBoxHeader = () => {
 };
 
 const SelectItemListBoxTitle = styled.div.attrs({ children: '조회할 주 선택' })`
-  font-family: SFProDisplay;
   font-size: 17px;
   color: #121111;
 `;

--- a/src/templates/SubHeader/index.tsx
+++ b/src/templates/SubHeader/index.tsx
@@ -15,14 +15,12 @@ export const SubHeader = () => (
 );
 
 const Title = styled.div`
-  font-family: AppleSDGothicNeo;
   font-size: 13px;
   font-weight: 500;
   color: #121111;
 `;
 
 const SortLabel = styled.span`
-  font-family: AppleSDGothicNeo;
   font-size: 11px;
   font-weight: 500;
   color: #6d6f72;

--- a/src/templates/Tabs/Tab.tsx
+++ b/src/templates/Tabs/Tab.tsx
@@ -13,7 +13,6 @@ const TabLabel = styled.div<Pick<ITabProps, 'selected'>>`
   align-items: center;
   justify-content: center;
 
-  font-family: SFProDisplay;
   font-size: 16px;
   font-weight: 600;
 

--- a/src/templates/TextCard/index.tsx
+++ b/src/templates/TextCard/index.tsx
@@ -27,12 +27,10 @@ TextCard.defaultProps = {
 };
 
 const Title = styled.div`
-  font-family: SFProDisplay;
   font-weight: 600;
   color: #121111;
 `;
 
 const Text = styled.div`
-  font-family: SFProDisplay;
   color: #595966;
 `;


### PR DESCRIPTION
- 로고 아이콘 너비값/높이값 적용 후 가운데 정렬
- Footer의 anchor 태그에 하드 코딩으로 들어가진 width 값 제거
- 산재되어져있는 font-family 한곳에서 관리되도록 변경